### PR TITLE
Fix install-docker-ce.ps1: On PS >=5, use Invoke-WebRequest instead of non-existing function 'wget'

### DIFF
--- a/helpful_tools/Install-DockerCE/install-docker-ce.ps1
+++ b/helpful_tools/Install-DockerCE/install-docker-ce.ps1
@@ -451,7 +451,7 @@ Copy-File
             # We disable progress display because it kills performance for large downloads (at least on 64-bit PowerShell)
             #
             $ProgressPreference = 'SilentlyContinue'
-            wget -Uri $SourcePath -OutFile $DestinationPath -UseBasicParsing
+            Invoke-WebRequest -Uri $SourcePath -OutFile $DestinationPath -UseBasicParsing
             $ProgressPreference = 'Continue'
         }
         else


### PR DESCRIPTION
Guess the person who wrote this had aliased wget to Invoke-WebRequest? These are the arguments to Invoke-WebRequest, so something was a bit weird here.

Simple fix anyway. 