### PR TITLE
Expand-Archive progress-bar suppression

### DIFF
--- a/helpful_tools/Install-DockerCE/install-docker-ce.ps1
+++ b/helpful_tools/Install-DockerCE/install-docker-ce.ps1
@@ -606,8 +606,12 @@ Install-Docker()
 
         Write-Output "Downloading $zipUrl to $destinationFolder\docker-$version.zip"
         Copy-File -SourcePath $zipUrl -DestinationPath "$destinationFolder\docker-$version.zip"
-        Expand-Archive -Path "$destinationFolder\docker-$version.zip" -DestinationPath "$destinationFolder\docker-$version"
 
+        #Prevent issues with CLI non-interactive execution on Window Server 2019
+        $global:ProgressPreference = "SilentlyContinue"
+        Expand-Archive -Path "$destinationFolder\docker-$version.zip" -DestinationPath "$destinationFolder\docker-$version"
+        $global:ProgressPreference = "Continue"
+        
         if($DockerPath -eq "default") {
             $DockerPath = "$destinationFolder\docker-$version\docker\docker.exe"
         }


### PR DESCRIPTION
When running on Windows Server 2019 via SSH this results in `Win32 internal error "Access is denied" 0x5 occurred while reading the console output buffer. Contact Microsoft Customer Support Services.`.

Changes prevent issues with CLI non-interactive execution on Window Server 2019 by suppressing progress bar for Expand-Archive command (see: PowerShell/Microsoft.PowerShell.Archive#77)

Tested on Windows Server 2019 & 2022