### PR TITLE
Update code to use HNS powershell instead of deprecated command

### DIFF
--- a/helpful_tools/Install-ContainerdRuntime/install-containerd-runtime.ps1
+++ b/helpful_tools/Install-ContainerdRuntime/install-containerd-runtime.ps1
@@ -239,7 +239,15 @@ New-ContainerTransparentNetwork
     }
 
     Write-Output "Creating container network (Transparent)..."
-    New-ContainerNetwork -Name "Transparent" -Mode Transparent -NetworkAdapterName $netAdapter.Name | Out-Null
+    
+    # Download and Install powershell module HNS-Network
+    curl.exe -LO https://github.com/microsoft/windows-container-networking/releases/download/v0.3.0/windows-container-networking-cni-amd64-v0.3.0.zip
+    Expand-Archive -Path .\windows-container-networking-cni-amd64-v0.3.0.zip -DestinationPath 'C:\Program Files\containerd\cni\bin\'
+    curl.exe -LO https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1
+    Import-Module -Force ./hns.psm1
+
+    # Create Transparent network
+    New-HNSNetwork -Type Transparent -Name "Transparent" -AdapterName $netAdapter.Name | Out-Null
 }
 
 

--- a/helpful_tools/Install-ContainerdRuntime/install-containerd-runtime.ps1
+++ b/helpful_tools/Install-ContainerdRuntime/install-containerd-runtime.ps1
@@ -241,8 +241,11 @@ New-ContainerTransparentNetwork
     Write-Output "Creating container network (Transparent)..."
     
     # Download and Install powershell module HNS-Network
-    curl.exe -LO https://github.com/microsoft/windows-container-networking/releases/download/v0.3.0/windows-container-networking-cni-amd64-v0.3.0.zip
-    Expand-Archive -Path .\windows-container-networking-cni-amd64-v0.3.0.zip -DestinationPath 'C:\Program Files\containerd\cni\bin\'
+    $containerdPath='C:\Program Files\containerd\cni\bin\'
+    if (-not (Test-Path $containerdPath)){
+        curl.exe -LO https://github.com/microsoft/windows-container-networking/releases/download/v0.3.0/windows-container-networking-cni-amd64-v0.3.0.zip
+        Expand-Archive -Path .\windows-container-networking-cni-amd64-v0.3.0.zip -DestinationPath $containerdPath
+    }
     curl.exe -LO https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1
     Import-Module -Force ./hns.psm1
 

--- a/helpful_tools/Install-ContainerdRuntime/install-containerd-runtime.ps1
+++ b/helpful_tools/Install-ContainerdRuntime/install-containerd-runtime.ps1
@@ -229,6 +229,15 @@ Install-Feature
 function
 New-ContainerTransparentNetwork
 {
+    # Check if we've already created the container network
+    $networks = Get-HNSNetwork | Where-Object { $_.Name -eq "Transparent" }
+    if ($networks -ne $null)
+    {
+        Write-Output "Container network (Transparent) already exists. Skipping network creation".
+        return;
+    }
+
+    # Continue to create container network
     if ($ExternalNetAdapter)
     {
         $netAdapter = (Get-NetAdapter | Where-Object {$_.Name -eq "$ExternalNetAdapter"})[0]


### PR DESCRIPTION
Currently a deprecated command is used called "New-ContainerNetwork" is used in our scripts here, so replaced that with HNS. 

Solves issue: https://github.com/microsoft/Windows-Containers/issues/461

Tested by locally starting a servercore VM and running the updated script: .\install-containerd-runtime.ps1 -useDHCP, then used ctr to pull and start a container. 