### PR TITLE
Update code to use docker network instead of deprecated command

### DIFF
--- a/helpful_tools/Install-DockerCE/install-docker-ce.ps1
+++ b/helpful_tools/Install-DockerCE/install-docker-ce.ps1
@@ -250,6 +250,14 @@ Install-Feature
 function
 New-ContainerTransparentNetwork
 {
+    # Check if transparent network already created
+    $networkList = docker network ls 
+    if ($networkList -match '\bTransparent\b') {
+        Write-Output "Network with the name Transparent exists."
+        return
+    }
+ 
+    # Continue with network creation
     if ($ExternalNetAdapter)
     {
         $netAdapter = (Get-NetAdapter |? {$_.Name -eq "$ExternalNetAdapter"})[0]

--- a/helpful_tools/Install-DockerCE/install-docker-ce.ps1
+++ b/helpful_tools/Install-DockerCE/install-docker-ce.ps1
@@ -252,7 +252,8 @@ New-ContainerTransparentNetwork
 {
     # Check if transparent network already created
     $networkList = docker network ls 
-    if ($networkList -match '\bTransparent\b') {
+    if ($networkList -match '\bTransparent\b')
+    {
         Write-Output "Network with the name Transparent exists."
         return
     }


### PR DESCRIPTION
Currently a deprecated command is used called "New-ContainerNetwork" is used in our scripts here, so replacing it with docker network. Also, swapped docker install to happen before network creation so it can leverage the docker create network command.

Solves issue: #461

Tested by locally starting a servercore VM and running the updated script: .\install-docker-ce.ps1 -useDHCP, then used docker to pull and start a container.