### PR TITLE
add workflow to remind users of support policy

### DIFF
--- a/.github/workflows/policy-reminder.yml
+++ b/.github/workflows/policy-reminder.yml
@@ -1,0 +1,23 @@
+name: Policy Reminder
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  policy-reminder:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Remind New Issues of Support Policy
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const issueComment = context.issue({
+            body: `Thank you for creating an issue. Please note that GitHub is not an official 
+              channel for Microsoft support requests. To create an official support request, 
+              please open a ticket 
+              [here](https://learn.microsoft.com/en-us/services-hub/unified/support/open-support-requests).
+              Microsoft and the GitHub community strive to provide a best effort in answering
+              questions and supporting Issues on GitHub.`
+          });
+          github.issues.createComment(issueComment);


### PR DESCRIPTION
Want to articulate difference between Microsoft Support + GitHub Issues. Should be triggered automatically when a new Issue is created. Will need to check if it is blocked by policies for a Microsoft-run repo.