### PR TITLE
fix: use Microsoft-Hyper-V feature name on Windows Client SKUs

### DIFF
--- a/helpful_tools/Install-DockerCE/install-docker-ce.ps1
+++ b/helpful_tools/Install-DockerCE/install-docker-ce.ps1
@@ -303,7 +303,16 @@ Install-ContainerHost
 
     if ($HyperV)
     {
-        Install-Feature -FeatureName Hyper-V
+        # Add-WindowsFeature (ServerManager) uses "Hyper-V"; Enable-WindowsOptionalFeature (DISM)
+        # requires "Microsoft-Hyper-V". Pass the correct name depending on which API is available.
+        if (Get-Command Get-WindowsFeature -ErrorAction SilentlyContinue)
+        {
+            Install-Feature -FeatureName Hyper-V
+        }
+        else
+        {
+            Install-Feature -FeatureName Microsoft-Hyper-V
+        }
     }
 
     if ($global:RebootRequired)


### PR DESCRIPTION
Add-WindowsFeature (ServerManager) uses the feature name "Hyper-V", while Enable-WindowsOptionalFeature (DISM) requires "Microsoft-Hyper-V". On Windows Client SKUs, Get-WindowsFeature is unavailable so Install-Feature falls through to the DISM path, where "Hyper-V" is an unrecognized name and the feature is silently not enabled.

This caused `docker run` to fail with:
  hcs::CreateComputeSystem: The request is not supported.

Fix: check which API is available at the call site in Install-ContainerHost and pass the correct feature name to Install-Feature accordingly:
- Server SKUs (Get-WindowsFeature available): pass "Hyper-V"
- Client SKUs (DISM path):                   pass "Microsoft-Hyper-V"